### PR TITLE
feat: add url label

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -23,4 +23,5 @@ LABEL org.opencontainers.image.vendor="Traefik Labs" \
 	org.opencontainers.image.title="Traefik" \
 	org.opencontainers.image.description="A modern reverse-proxy" \
 	org.opencontainers.image.version="v2.3.7" \
-	org.opencontainers.image.documentation="https://docs.traefik.io"
+	org.opencontainers.image.documentation="https://docs.traefik.io" \
+    org.opencontainers.image.url="https://github.com/traefik/traefik"

--- a/alpine/tmplv1.Dockerfile
+++ b/alpine/tmplv1.Dockerfile
@@ -21,4 +21,5 @@ LABEL org.opencontainers.image.vendor="traefik" \
 	org.opencontainers.image.title="Traefik" \
 	org.opencontainers.image.description="A modern reverse-proxy" \
 	org.opencontainers.image.version="$VERSION" \
-	org.opencontainers.image.documentation="https://docs.traefik.io"
+	org.opencontainers.image.documentation="https://docs.traefik.io" \
+    org.opencontainers.image.url="https://github.com/traefik/traefik"

--- a/alpine/tmplv2.Dockerfile
+++ b/alpine/tmplv2.Dockerfile
@@ -23,4 +23,5 @@ LABEL org.opencontainers.image.vendor="Traefik Labs" \
 	org.opencontainers.image.title="Traefik" \
 	org.opencontainers.image.description="A modern reverse-proxy" \
 	org.opencontainers.image.version="$VERSION" \
-	org.opencontainers.image.documentation="https://docs.traefik.io"
+	org.opencontainers.image.documentation="https://docs.traefik.io" \
+    org.opencontainers.image.url="https://github.com/traefik/traefik"

--- a/scratch/Dockerfile
+++ b/scratch/Dockerfile
@@ -13,4 +13,5 @@ LABEL org.opencontainers.image.vendor="Traefik Labs" \
 	org.opencontainers.image.title="Traefik" \
 	org.opencontainers.image.description="A modern reverse-proxy" \
 	org.opencontainers.image.version="v2.3.7" \
-	org.opencontainers.image.documentation="https://docs.traefik.io"
+	org.opencontainers.image.documentation="https://docs.traefik.io" \
+    org.opencontainers.image.url="https://github.com/traefik/traefik"

--- a/scratch/tmplv1.Dockerfile
+++ b/scratch/tmplv1.Dockerfile
@@ -13,4 +13,5 @@ LABEL org.opencontainers.image.vendor="Traefik Labs" \
 	org.opencontainers.image.title="Traefik" \
 	org.opencontainers.image.description="A modern reverse-proxy" \
 	org.opencontainers.image.version="$VERSION" \
-	org.opencontainers.image.documentation="https://docs.traefik.io"
+	org.opencontainers.image.documentation="https://docs.traefik.io" \
+    org.opencontainers.image.url="https://github.com/traefik/traefik"

--- a/scratch/tmplv2.Dockerfile
+++ b/scratch/tmplv2.Dockerfile
@@ -13,4 +13,5 @@ LABEL org.opencontainers.image.vendor="Traefik Labs" \
 	org.opencontainers.image.title="Traefik" \
 	org.opencontainers.image.description="A modern reverse-proxy" \
 	org.opencontainers.image.version="$VERSION" \
-	org.opencontainers.image.documentation="https://docs.traefik.io"
+	org.opencontainers.image.documentation="https://docs.traefik.io" \
+    org.opencontainers.image.url="https://github.com/traefik/traefik"

--- a/windows/1809/Dockerfile
+++ b/windows/1809/Dockerfile
@@ -16,4 +16,5 @@ LABEL org.opencontainers.image.vendor="Traefik Labs" \
     org.opencontainers.image.title="Traefik" \
     org.opencontainers.image.description="A modern reverse-proxy" \
     org.opencontainers.image.version="v2.3.7" \
-    org.opencontainers.image.documentation="https://docs.traefik.io"
+    org.opencontainers.image.documentation="https://docs.traefik.io" \
+    org.opencontainers.image.url="https://github.com/traefik/traefik"

--- a/windows/1809/tmplv1.Dockerfile
+++ b/windows/1809/tmplv1.Dockerfile
@@ -14,4 +14,5 @@ LABEL org.opencontainers.image.vendor="Traefik Labs" \
     org.opencontainers.image.title="Traefik" \
     org.opencontainers.image.description="A modern reverse-proxy" \
     org.opencontainers.image.version="$VERSION" \
-    org.opencontainers.image.documentation="https://docs.traefik.io"
+    org.opencontainers.image.documentation="https://docs.traefik.io" \
+    org.opencontainers.image.url="https://github.com/traefik/traefik"

--- a/windows/1809/tmplv2.Dockerfile
+++ b/windows/1809/tmplv2.Dockerfile
@@ -16,4 +16,5 @@ LABEL org.opencontainers.image.vendor="Traefik Labs" \
     org.opencontainers.image.title="Traefik" \
     org.opencontainers.image.description="A modern reverse-proxy" \
     org.opencontainers.image.version="$VERSION" \
-    org.opencontainers.image.documentation="https://docs.traefik.io"
+    org.opencontainers.image.documentation="https://docs.traefik.io" \
+    org.opencontainers.image.url="https://github.com/traefik/traefik"


### PR DESCRIPTION
This pr will add the official `org.opencontainers.image.url` docker label pointing to the traefik source code repo.

With this label apps like [renovate](https://github.com/renovatebot/renovate) can find the source code repo to extract the changelogs.