### PR TITLE
Add nanoserver-1809 Windows container images (much smaller, still works!)

### DIFF
--- a/nanoserver/1809/Dockerfile
+++ b/nanoserver/1809/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+USER ContainerAdministrator
+COPY --from=traefik:v2.4.8-windowsservercore-1809 \
+    C:\\traefik.exe C:\\traefik.exe
+
+EXPOSE 80
+ENTRYPOINT [ "/traefik" ]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Traefik Labs" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="v2.4.8" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"

--- a/nanoserver/1809/tmplv1.Dockerfile
+++ b/nanoserver/1809/tmplv1.Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+USER ContainerAdministrator
+COPY --from=traefik:${VERSION}-windowsservercore-1809 \
+    C:\\traefik.exe C:\\traefik.exe
+
+EXPOSE 80
+ENTRYPOINT [ "/traefik" ]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Traefik Labs" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="$VERSION" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"

--- a/nanoserver/1809/tmplv2.Dockerfile
+++ b/nanoserver/1809/tmplv2.Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+USER ContainerAdministrator
+COPY --from=traefik:${VERSION}-windowsservercore-1809 \
+    C:\\traefik.exe C:\\traefik.exe
+
+EXPOSE 80
+ENTRYPOINT [ "/traefik" ]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Traefik Labs" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="$VERSION" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"


### PR DESCRIPTION
This pull request adds nanoserver-1809 Windows container images for traefik, as a complement for the servercore-1809 container images. The nanoserver images are MUCH smaller than the servercore images, but they have less Windows host compatibility. The nanoserver-1809 tag is compatible with Windows Server 2019 with process-level isolation, but it can still be run on Windows 10 with Hyper-V isolation. One small difference between nanoserver is that it uses ContainerUser instead of ContainerAdministrator by default, I've changed it to avoid potential issues with regards to file permissions, making it usable as a drop-in replacement for the servercore images.

I am not very familiar with the structure of this repository, but I noticed that there were v1 and v2 Dockerfile templates, and a Dockerfile containing the latest 1.x version. I made both templates but I used the latest 2.x in the non-templated Dockerfile for testing. I built the dockerfile like this: `docker build . -t v2.4.8-traefik-nanoserver-1809` and I was able to use it as a replacement for the corresponding servercore image.

Notice that I've used "nanoserver-1809" as the container tag, and not "windowsnanoserver-1809". Just like we don't repeat "alpinelinux" in "alpine" tags, we don't really need to repeat "windows" in "servercore" and "nanoserver" tags. [I have recently helped MongoDB get their nanoserver container images](https://github.com/docker-library/mongo/pull/470), and they've decided to use "nanoserver" instead of "windowsnanoserver", so I suggest traefik just follows the same convention. I use the same one for all of my own container images, and most [windows container images now use this convention](https://hub.docker.com/_/microsoft-powershell).

Let me know if you have any questions, I'd be more than happy to help. I just want official nanoserver traefik images upstream to avoid the need to separately maintain unofficial container images on my side. traefik and mongo were the only two third-party containers I needed to fully complete my switch to nanoserver.