### PR TITLE
Feat: Adding Support for Privileged Ports with Unprivileged Users on K8s

### DIFF
--- a/alpine-k8s/Dockerfile
+++ b/alpine-k8s/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:3.14
+RUN apk --no-cache add ca-certificates tzdata
+RUN set -ex; \
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		armhf) arch='armv6' ;; \
+		aarch64) arch='arm64' ;; \
+		x86_64) arch='amd64' ;; \
+		*) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
+	esac; \
+	wget --quiet -O /tmp/traefik.tar.gz "https://github.com/traefik/traefik/releases/download/v2.6.0/traefik_v2.6.0_linux_$arch.tar.gz"; \
+	tar xzvf /tmp/traefik.tar.gz -C /usr/local/bin traefik; \
+	rm -f /tmp/traefik.tar.gz; \
+	chmod +x /usr/local/bin/traefik; \
+	apk add libcap; \
+	setcap 'cap_net_bind_service=+ep' /usr/local/bin/traefik; \
+	apk del libcap
+COPY entrypoint.sh /
+EXPOSE 80
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["traefik"]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Traefik Labs" \
+	org.opencontainers.image.url="https://traefik.io" \
+	org.opencontainers.image.title="Traefik" \
+	org.opencontainers.image.description="A modern reverse-proxy" \
+	org.opencontainers.image.version="v2.6.0" \
+	org.opencontainers.image.documentation="https://docs.traefik.io"

--- a/alpine-k8s/entrypoint.sh
+++ b/alpine-k8s/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+    set -- traefik "$@"
+fi
+
+# if our command is a valid Traefik subcommand, let's invoke it through Traefik instead
+# (this allows for "docker run traefik version", etc)
+if traefik "$1" --help >/dev/null 2>&1
+then
+    set -- traefik "$@"
+else
+    echo "= '$1' is not a Traefik command: assuming shell execution." 1>&2
+fi
+
+exec "$@"

--- a/alpine-k8s/tmplv1.Dockerfile
+++ b/alpine-k8s/tmplv1.Dockerfile
@@ -1,0 +1,27 @@
+FROM alpine:$ALPINE_VERSION
+RUN apk --no-cache add ca-certificates tzdata
+RUN set -ex; \
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		armhf) arch='arm' ;; \
+		aarch64) arch='arm64' ;; \
+		x86_64) arch='amd64' ;; \
+		*) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
+	esac; \
+	wget --quiet -O /usr/local/bin/traefik "https://github.com/traefik/traefik/releases/download/$VERSION/traefik_linux-$arch"; \
+	chmod +x /usr/local/bin/traefik; \
+	apk add libcap; \
+	setcap 'cap_net_bind_service=+ep' /usr/local/bin/traefik; \
+	apk del libcap
+COPY entrypoint.sh /
+EXPOSE 80
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["traefik"]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="traefik" \
+	org.opencontainers.image.url="https://traefik.io" \
+	org.opencontainers.image.title="Traefik" \
+	org.opencontainers.image.description="A modern reverse-proxy" \
+	org.opencontainers.image.version="$VERSION" \
+	org.opencontainers.image.documentation="https://docs.traefik.io"

--- a/alpine-k8s/tmplv2.Dockerfile
+++ b/alpine-k8s/tmplv2.Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:$ALPINE_VERSION
+RUN apk --no-cache add ca-certificates tzdata
+RUN set -ex; \
+	apkArch="$(apk --print-arch)"; \
+	case "$apkArch" in \
+		armhf) arch='armv6' ;; \
+		aarch64) arch='arm64' ;; \
+		x86_64) arch='amd64' ;; \
+		*) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
+	esac; \
+	wget --quiet -O /tmp/traefik.tar.gz "https://github.com/traefik/traefik/releases/download/${VERSION}/traefik_${VERSION}_linux_$arch.tar.gz"; \
+	tar xzvf /tmp/traefik.tar.gz -C /usr/local/bin traefik; \
+	rm -f /tmp/traefik.tar.gz; \
+	chmod +x /usr/local/bin/traefik; \
+	apk add libcap; \
+	setcap 'cap_net_bind_service=+ep' /usr/local/bin/traefik; \
+	apk del libcap
+COPY entrypoint.sh /
+EXPOSE 80
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["traefik"]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Traefik Labs" \
+	org.opencontainers.image.url="https://traefik.io" \
+	org.opencontainers.image.title="Traefik" \
+	org.opencontainers.image.description="A modern reverse-proxy" \
+	org.opencontainers.image.version="$VERSION" \
+	org.opencontainers.image.documentation="https://docs.traefik.io"

--- a/update.sh
+++ b/update.sh
@@ -12,6 +12,7 @@ export VERSION=$1
 export ALPINE_VERSION=3.14
 PLATFORMS=(
 	"alpine"
+	"alpine-k8s"
 	"scratch"
 	"windows/1809"
 )


### PR DESCRIPTION
As mentioned in #7  , we need the ability to run Traefik using privileged ports with non-privileged users. 
This is similar to the Nginx implementation for kubernetes. This allows for a separate traefik image to be built.

Fixes: https://github.com/traefik/traefik-helm-chart/issues/336
