### PR TITLE
feat: add support for privileged ports usage without root user

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.15
-RUN apk --no-cache add ca-certificates tzdata
+RUN apk --no-cache add ca-certificates tzdata libcap
 RUN set -ex; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
@@ -12,7 +12,9 @@ RUN set -ex; \
 	wget --quiet -O /tmp/traefik.tar.gz "https://github.com/traefik/traefik/releases/download/v2.9.1/traefik_v2.9.1_linux_$arch.tar.gz"; \
 	tar xzvf /tmp/traefik.tar.gz -C /usr/local/bin traefik; \
 	rm -f /tmp/traefik.tar.gz; \
-	chmod +x /usr/local/bin/traefik
+	chmod +x /usr/local/bin/traefik ; \
+	setcap 'cap_net_bind_service=+ep' /usr/local/bin/traefik; \
+	apk del libcap
 COPY entrypoint.sh /
 EXPOSE 80
 ENTRYPOINT ["/entrypoint.sh"]

--- a/alpine/tmplv2.Dockerfile
+++ b/alpine/tmplv2.Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:$ALPINE_VERSION
-RUN apk --no-cache add ca-certificates tzdata
+RUN apk --no-cache add ca-certificates tzdata libcap
 RUN set -ex; \
 	apkArch="$(apk --print-arch)"; \
 	case "$apkArch" in \
@@ -12,7 +12,9 @@ RUN set -ex; \
 	wget --quiet -O /tmp/traefik.tar.gz "https://github.com/traefik/traefik/releases/download/${VERSION}/traefik_${VERSION}_linux_$arch.tar.gz"; \
 	tar xzvf /tmp/traefik.tar.gz -C /usr/local/bin traefik; \
 	rm -f /tmp/traefik.tar.gz; \
-	chmod +x /usr/local/bin/traefik
+	chmod +x /usr/local/bin/traefik; \
+	setcap 'cap_net_bind_service=+ep' /usr/local/bin/traefik; \
+	apk del libcap
 COPY entrypoint.sh /
 EXPOSE 80
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
When user wants to run `traefik` docker image without being root, he cannot listen on ports < 1024 by default. The binary needs a special capability in order for him to do so. 

This PR add this capability to `traefik` binary, since Traefik is expected to listen on ports like 443 or 80.

UPDATE: It seems recent version of Docker removes the needs of this capability cf [this commit](https://github.com/moby/moby/pull/41030/files#diff-9f91bff23e0bd70d6429b63d9db2d8180d2e89cdb64db4fb3e10a96f74d36271R790).

Supersedes #18
Fixes #7

### Additional Informations

Co-authored-by: Samuel MARTIN MORO <faust64@gmail.com>
Co-authored-by: Mandus Momberg <git@momberg.me>
