### PR TITLE
feat: add Windows LTSC 2022 Server support

### DIFF
--- a/.ci/test.ps1
+++ b/.ci/test.ps1
@@ -1,3 +1,10 @@
+param(
+    [Parameter()]
+    [String]$target
+)
+
+Write-Output 'Test for ' + $target
+
 $ErrorActionPreference = 'Stop' # Fail if any instruction fails
 $version = Get-Content .\version -Raw
 $api_opts = ''
@@ -5,11 +12,8 @@ if($version.StartsWith('v2')) {
 $api_opts='--api.insecure'
 }
 
-$platform = 'windows-1809'
-$platform_dir = './windows/1809/'
-
-docker build -t traefik:$platform $platform_dir
-docker run --name lb -d -p 8080:8080 traefik:$platform --api $api_opts
+docker build -t traefik:$target windows/$target
+docker run --name lb -d -p 8080:8080 traefik:$target --api $api_opts
 sleep 2
 docker ps
 Invoke-WebRequest -Uri http://localhost:8080 -TimeoutSec 60

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 jobs:
 
   docker-library-linux:
-    name: Test Traefik docker image on linux
+    name: Test on linux
     runs-on: ubuntu-latest
 
     steps:
@@ -26,8 +26,8 @@ jobs:
       - name: Test
         run: ./.ci/test.sh
 
-  docker-library-windows:
-    name: Test Traefik docker image on windows
+  docker-library-win1809:
+    name: Test on windows server 2019
     runs-on: windows-2019
 
     steps:
@@ -38,5 +38,20 @@ jobs:
           fetch-depth: 1
 
       - name: Test
-        run: .\.ci\test.ps1
+        run: .\.ci\test.ps1 -target '1809'
+        shell: powershell
+
+  docker-library-wincore2022:
+    name: Test on windows server core 2022
+    runs-on: windows-2022
+
+    steps:
+
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Test
+        run: .\.ci\test.ps1 -target 'servercore-ltsc2022'
         shell: powershell

--- a/update.sh
+++ b/update.sh
@@ -14,6 +14,7 @@ PLATFORMS=(
 	"alpine"
 	"scratch"
 	"windows/1809"
+	"windows/servercore-ltsc2022"
 )
 
 SCRIPT_DIRNAME_ABSOLUTEPATH="$(cd "$(dirname "$0")" && pwd -P)"

--- a/windows/servercore-ltsc2022/Dockerfile
+++ b/windows/servercore-ltsc2022/Dockerfile
@@ -1,0 +1,19 @@
+FROM  mcr.microsoft.com/windows/servercore:ltsc2022
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest \
+        -Uri "https://github.com/traefik/traefik/releases/download/v2.9.1/traefik_v2.9.1_windows_amd64.zip" \
+        -OutFile "/traefik.zip"; \
+    Expand-Archive -Path "/traefik.zip" -DestinationPath "/" -Force; \
+    Remove-Item "/traefik.zip" -Force
+
+EXPOSE 80
+ENTRYPOINT [ "/traefik" ]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Traefik Labs" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="v2.9.1" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"

--- a/windows/servercore-ltsc2022/tmplv2.Dockerfile
+++ b/windows/servercore-ltsc2022/tmplv2.Dockerfile
@@ -1,0 +1,19 @@
+FROM  mcr.microsoft.com/windows/servercore:ltsc2022
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest \
+        -Uri "https://github.com/traefik/traefik/releases/download/${VERSION}/traefik_${VERSION}_windows_amd64.zip" \
+        -OutFile "/traefik.zip"; \
+    Expand-Archive -Path "/traefik.zip" -DestinationPath "/" -Force; \
+    Remove-Item "/traefik.zip" -Force
+
+EXPOSE 80
+ENTRYPOINT [ "/traefik" ]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Traefik Labs" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="$VERSION" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"


### PR DESCRIPTION
Following PR #2 , #9 and [this update](https://github.com/docker-library/official-images/issues/9198#issuecomment-904994195) from Docker Hub team, it seems that it's now possible to provide _official_ 2022 images.

Edit: It seems it's currently not possible to provide `nano` images, so I removed nano build from this PR.