### PR TITLE
Update Alpine to 3.18

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -9,7 +9,7 @@ if [ $# -eq 0 ] ; then
 fi
 
 export VERSION=$1
-export ALPINE_VERSION=3.17
+export ALPINE_VERSION=3.18
 PLATFORMS=(
 	"alpine"
 	"scratch"


### PR DESCRIPTION
This updates Alpine to the latest stable version, 3.18 (see also https://alpinelinux.org/posts/Alpine-3.18.0-released.html).