### PR TITLE
Update to Alpine 3.19

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -9,7 +9,7 @@ if [ $# -eq 0 ] ; then
 fi
 
 export VERSION=$1
-export ALPINE_VERSION=3.18
+export ALPINE_VERSION=3.19
 PLATFORMS=(
 	"alpine"
 	"scratch"


### PR DESCRIPTION
This updates Alpine to the latest stable version: 3.19.

See also https://alpinelinux.org/posts/Alpine-3.19.0-released.html.

*Note: the Alpine 3.19 base Docker image is yet to appear [here](https://hub.docker.com/_/alpine/tags), so automated checks might fail up till then.*