### PR TITLE
Allow traefik to bind to service ports when not running as root

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -12,7 +12,8 @@ RUN set -ex; \
 	wget --quiet -O /tmp/traefik.tar.gz "https://github.com/traefik/traefik/releases/download/v2.11.0-rc1/traefik_v2.11.0-rc1_linux_$arch.tar.gz"; \
 	tar xzvf /tmp/traefik.tar.gz -C /usr/local/bin traefik; \
 	rm -f /tmp/traefik.tar.gz; \
-	chmod +x /usr/local/bin/traefik
+	chmod +x /usr/local/bin/traefik; \
+	apk --no-cache add libcap && setcap cap_net_bind_service=+ep /usr/local/bin/traefik && apk del -r libcap
 COPY entrypoint.sh /
 EXPOSE 80
 ENTRYPOINT ["/entrypoint.sh"]

--- a/alpine/tmplv1.Dockerfile
+++ b/alpine/tmplv1.Dockerfile
@@ -9,7 +9,8 @@ RUN set -ex; \
 		*) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
 	esac; \
 	wget --quiet -O /usr/local/bin/traefik "https://github.com/traefik/traefik/releases/download/$VERSION/traefik_linux-$arch"; \
-	chmod +x /usr/local/bin/traefik
+	chmod +x /usr/local/bin/traefik; \
+	apk --no-cache add libcap && setcap cap_net_bind_service=+ep /usr/local/bin/traefik && apk del -r libcap
 COPY entrypoint.sh /
 EXPOSE 80
 ENTRYPOINT ["/entrypoint.sh"]

--- a/alpine/tmplv2.Dockerfile
+++ b/alpine/tmplv2.Dockerfile
@@ -12,7 +12,8 @@ RUN set -ex; \
 	wget --quiet -O /tmp/traefik.tar.gz "https://github.com/traefik/traefik/releases/download/${VERSION}/traefik_${VERSION}_linux_$arch.tar.gz"; \
 	tar xzvf /tmp/traefik.tar.gz -C /usr/local/bin traefik; \
 	rm -f /tmp/traefik.tar.gz; \
-	chmod +x /usr/local/bin/traefik
+	chmod +x /usr/local/bin/traefik; \
+	apk --no-cache add libcap && setcap cap_net_bind_service=+ep /usr/local/bin/traefik && apk del -r libcap
 COPY entrypoint.sh /
 EXPOSE 80
 ENTRYPOINT ["/entrypoint.sh"]

--- a/alpine/tmplv3.Dockerfile
+++ b/alpine/tmplv3.Dockerfile
@@ -12,7 +12,8 @@ RUN set -ex; \
 	wget --quiet -O /tmp/traefik.tar.gz "https://github.com/traefik/traefik/releases/download/${VERSION}/traefik_${VERSION}_linux_$arch.tar.gz"; \
 	tar xzvf /tmp/traefik.tar.gz -C /usr/local/bin traefik; \
 	rm -f /tmp/traefik.tar.gz; \
-	chmod +x /usr/local/bin/traefik
+	chmod +x /usr/local/bin/traefik; \
+	apk --no-cache add libcap && setcap cap_net_bind_service=+ep /usr/local/bin/traefik && apk del -r libcap
 COPY entrypoint.sh /
 EXPOSE 80
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Description

This pull request allows Traefik to bind to service ports (< port number 1024) by setting `cap_net_bind_service` on the Traefik binary.

This allows to start Traefik as non-root user in Kubernetes and drop all capabilities except `NET_BIND_SERVICE`, e.g. using the following `securityContext`:

```yaml
      securityContext:
        allowPrivilegeEscalation: false
        readOnlyRootFilesystem: true
        runAsNonRoot: true
        capabilities:
          drop: [ALL]
          add: [NET_BIND_SERVICE]
```

This feature has been requested multiple times, e.g.:

* [unprivileged images for Kubernetes #7](https://github.com/traefik/traefik-library-image/issues/7)
* [Traefik as non-root should be default](https://community.traefik.io/t/traefik-as-non-root-should-be-default/16573)

and would allow us to run Traefik in a more secure way

## Background

There has been some discussion that adding `NET_BIND_SERVICE` is enough to achieve this, and the image need not be changed. However, this is not sufficient. In order to work correctly, the capability has to be added to the Pod in Kubernetes *and* also be set on the binary with `setcap`.
