### PR TITLE
Add new Dockerfile with distroless/static-debian12 for secure deploym…

### DIFF
--- a/distroless/Dockerfile
+++ b/distroless/Dockerfile
@@ -1,0 +1,30 @@
+# Base image with specified Traefik version
+ARG VERSION="v3.0.0-rc1"
+# Base image with specified Traefik version
+FROM traefik:${VERSION} as base
+
+# Final image based on Distroless for security and minimal size
+FROM gcr.io/distroless/static-debian12
+
+# Copy the Traefik binary from the base image
+COPY --from=base /usr/local/bin/traefik /
+
+# Set metadata using labels
+LABEL org.opencontainers.image.vendor="Traefik Labs" \
+      org.opencontainers.image.url="https://traefik.io" \
+      org.opencontainers.image.title="Traefik" \
+      org.opencontainers.image.description="A modern reverse-proxy" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.documentation="https://docs.traefik.io"
+
+# Use non-root user for better security
+USER nonroot
+
+# Expose default HTTP port
+EXPOSE 80
+
+# Define volume for temporary data
+VOLUME ["/tmp"]
+
+# Set entrypoint to run Traefik
+ENTRYPOINT ["/traefik"]

--- a/distroless/tmplv1.Dockerfile
+++ b/distroless/tmplv1.Dockerfile
@@ -1,0 +1,31 @@
+# Base image with specified Traefik version
+ARG VERSION
+
+# Base image with specified Traefik version
+FROM traefik:${VERSION} as base
+
+# Final image based on Distroless for security and minimal size
+FROM gcr.io/distroless/static-debian12
+
+# Copy the Traefik binary from the base image
+COPY --from=base /usr/local/bin/traefik /
+
+# Set metadata using labels
+LABEL org.opencontainers.image.vendor="Traefik Labs" \
+      org.opencontainers.image.url="https://traefik.io" \
+      org.opencontainers.image.title="Traefik" \
+      org.opencontainers.image.description="A modern reverse-proxy" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.documentation="https://docs.traefik.io"
+
+# Use non-root user for better security
+USER nonroot
+
+# Expose default HTTP port
+EXPOSE 80
+
+# Define volume for temporary data
+VOLUME ["/tmp"]
+
+# Set entrypoint to run Traefik
+ENTRYPOINT ["/traefik"]

--- a/distroless/tmplv2.Dockerfile
+++ b/distroless/tmplv2.Dockerfile
@@ -1,0 +1,31 @@
+# Base image with specified Traefik version
+ARG VERSION
+
+# Base image with specified Traefik version
+FROM traefik:${VERSION} as base
+
+# Final image based on Distroless for security and minimal size
+FROM gcr.io/distroless/static-debian12
+
+# Copy the Traefik binary from the base image
+COPY --from=base /usr/local/bin/traefik /
+
+# Set metadata using labels
+LABEL org.opencontainers.image.vendor="Traefik Labs" \
+      org.opencontainers.image.url="https://traefik.io" \
+      org.opencontainers.image.title="Traefik" \
+      org.opencontainers.image.description="A modern reverse-proxy" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.documentation="https://docs.traefik.io"
+
+# Use non-root user for better security
+USER nonroot
+
+# Expose default HTTP port
+EXPOSE 80
+
+# Define volume for temporary data
+VOLUME ["/tmp"]
+
+# Set entrypoint to run Traefik
+ENTRYPOINT ["/traefik"]

--- a/distroless/tmplv3.Dockerfile
+++ b/distroless/tmplv3.Dockerfile
@@ -1,0 +1,31 @@
+# Base image with specified Traefik version
+ARG VERSION
+
+# Base image with specified Traefik version
+FROM traefik:${VERSION} as base
+
+# Final image based on Distroless for security and minimal size
+FROM gcr.io/distroless/static-debian12
+
+# Copy the Traefik binary from the base image
+COPY --from=base /usr/local/bin/traefik /
+
+# Set metadata using labels
+LABEL org.opencontainers.image.vendor="Traefik Labs" \
+      org.opencontainers.image.url="https://traefik.io" \
+      org.opencontainers.image.title="Traefik" \
+      org.opencontainers.image.description="A modern reverse-proxy" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.documentation="https://docs.traefik.io"
+
+# Use non-root user for better security
+USER nonroot
+
+# Expose default HTTP port
+EXPOSE 80
+
+# Define volume for temporary data
+VOLUME ["/tmp"]
+
+# Set entrypoint to run Traefik
+ENTRYPOINT ["/traefik"]


### PR DESCRIPTION
This pull request introduces four new Dockerfiles to the project, each utilizing gcr.io/distroless/static-debian12 as their base image. The request to use Distroless images stems from a desire to enhance the security, efficiency, and maintainability of our containerized applications. Distroless images provide the minimal runtime environment necessary for the applications to run, thereby reducing the attack surface and the overhead associated with managing unnecessary packages and dependencies.

This effort directly addresses the requirements and discussions outlined in issue #55