### PR TITLE
feat: add Windows LTSC 2022 Nano Server support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,3 +55,18 @@ jobs:
       - name: Test
         run: .\.ci\test.ps1 -target 'servercore-ltsc2022'
         shell: powershell
+
+  docker-library-winnano2022:
+    name: Test on windows nano server 2022
+    runs-on: windows-2022
+
+    steps:
+
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Test
+        run: .\.ci\test.ps1 -target 'nanoserver-ltsc2022'
+        shell: powershell

--- a/update.sh
+++ b/update.sh
@@ -14,6 +14,7 @@ PLATFORMS=(
 	"alpine"
 	"scratch"
 	"windows/1809"
+	"windows/nanoserver-ltsc2022"
 	"windows/servercore-ltsc2022"
 )
 

--- a/windows/nanoserver-ltsc2022/Dockerfile
+++ b/windows/nanoserver-ltsc2022/Dockerfile
@@ -1,0 +1,26 @@
+# Installer image, needed for Invoke-WebRequest
+FROM  mcr.microsoft.com/windows/servercore:ltsc2022 AS installer
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest \
+        -Uri "https://github.com/traefik/traefik/releases/download/v3.0.0-rc5/traefik_v3.0.0-rc5_windows_amd64.zip" \
+        -OutFile "/traefik.zip"; \
+    Expand-Archive -Path "/traefik.zip" -DestinationPath "/" -Force; \
+    Remove-Item "/traefik.zip" -Force
+
+# Runner image
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+
+COPY --from=installer /traefik.exe /
+
+EXPOSE 80
+ENTRYPOINT [ "/traefik" ]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Traefik Labs" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.source="https://github.com/traefik/traefik" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="v3.0.0-rc5" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"

--- a/windows/nanoserver-ltsc2022/tmplv2.Dockerfile
+++ b/windows/nanoserver-ltsc2022/tmplv2.Dockerfile
@@ -1,0 +1,26 @@
+# Installer image, needed for Invoke-WebRequest
+FROM  mcr.microsoft.com/windows/servercore:ltsc2022 AS installer
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest \
+        -Uri "https://github.com/traefik/traefik/releases/download/${VERSION}/traefik_${VERSION}_windows_amd64.zip" \
+        -OutFile "/traefik.zip"; \
+    Expand-Archive -Path "/traefik.zip" -DestinationPath "/" -Force; \
+    Remove-Item "/traefik.zip" -Force
+
+# Runner image
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+
+COPY --from=installer /traefik.exe /
+
+EXPOSE 80
+ENTRYPOINT [ "/traefik" ]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Traefik Labs" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.source="https://github.com/traefik/traefik" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="$VERSION" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"

--- a/windows/nanoserver-ltsc2022/tmplv3.Dockerfile
+++ b/windows/nanoserver-ltsc2022/tmplv3.Dockerfile
@@ -1,0 +1,26 @@
+# Installer image, needed for Invoke-WebRequest
+FROM  mcr.microsoft.com/windows/servercore:ltsc2022 AS installer
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+RUN Invoke-WebRequest \
+        -Uri "https://github.com/traefik/traefik/releases/download/${VERSION}/traefik_${VERSION}_windows_amd64.zip" \
+        -OutFile "/traefik.zip"; \
+    Expand-Archive -Path "/traefik.zip" -DestinationPath "/" -Force; \
+    Remove-Item "/traefik.zip" -Force
+
+# Runner image
+FROM mcr.microsoft.com/windows/nanoserver:ltsc2022
+
+COPY --from=installer /traefik.exe /
+
+EXPOSE 80
+ENTRYPOINT [ "/traefik" ]
+
+# Metadata
+LABEL org.opencontainers.image.vendor="Traefik Labs" \
+    org.opencontainers.image.url="https://traefik.io" \
+    org.opencontainers.image.source="https://github.com/traefik/traefik" \
+    org.opencontainers.image.title="Traefik" \
+    org.opencontainers.image.description="A modern reverse-proxy" \
+    org.opencontainers.image.version="$VERSION" \
+    org.opencontainers.image.documentation="https://docs.traefik.io"


### PR DESCRIPTION
# Motivation

Following PR #32, based on how microsoft is building [dotnet nano image](https://github.com/dotnet/dotnet-docker/blob/9ffd75ed9a9a8790e7c7af5c925eefe7e4015bc1/src/aspnet/8.0/nanoserver-ltsc2022/amd64/Dockerfile), it seems it's now possible to provide _official_ nano server image.