### PR TITLE
Bump alpine version to 3.20 in Dockerfile

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.19
+FROM alpine:3.20
 RUN apk --no-cache add ca-certificates tzdata
 RUN set -ex; \
 	apkArch="$(apk --print-arch)"; \


### PR DESCRIPTION
## Motivation

This pull request bumps the alpine version in the Dockerfile used for templating which was not updated in https://github.com/traefik/traefik-library-image/pull/61