### PR TITLE
Update to Alpine 3.21

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -10,7 +10,7 @@ if [ $# -eq 0 ] ; then
 fi
 
 export VERSION=$1
-export ALPINE_VERSION=3.20
+export ALPINE_VERSION=3.21
 PLATFORMS=(
 	"alpine"
 	"scratch"


### PR DESCRIPTION
Modelled after #61.

This updates Alpine to the latest stable version: 3.21.

See also https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.21.0.

*Note: the Alpine 3.21 base Docker image is yet to appear [here](https://hub.docker.com/_/alpine/tags), so automated checks might fail up till then. See also https://github.com/docker-library/official-images/pull/18024.*