### PR TITLE
Remove awesome.traefik.io reference reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,5 +134,3 @@ You can find the complete documentation:
 - for [v2.11](https://doc.traefik.io/traefik/v2.11)
 
 A community support is available at [https://community.traefik.io](https://community.traefik.io)
-
-A collection of contributions around Traefik can be found at [https://awesome.traefik.io](https://awesome.traefik.io).


### PR DESCRIPTION
## Motivation

This pull request removes the `awesome.traefik.io` dead link from the README.