### PR TITLE
Update to Alpine 3.22

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -10,7 +10,7 @@ if [ $# -eq 0 ] ; then
 fi
 
 export VERSION=$1
-export ALPINE_VERSION=3.21
+export ALPINE_VERSION=3.22
 PLATFORMS=(
 	"alpine"
 	"scratch"


### PR DESCRIPTION
Modelled after #74.

This updates Alpine to the latest stable version: 3.22.

See also https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.22.0.