### PR TITLE
Update to Alpine 3.24

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -10,7 +10,7 @@ if [ $# -eq 0 ] ; then
 fi
 
 export VERSION=$1
-export ALPINE_VERSION=3.23
+export ALPINE_VERSION=3.24
 PLATFORMS=(
 	"alpine"
 	"scratch"


### PR DESCRIPTION
Modelled after #89.

This updates Alpine to the latest stable version: 3.24.

See also https://alpinelinux.org/posts/Alpine-3.24.0-released.html.